### PR TITLE
updating to support 4.3.10 of sauceconnect

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,3 @@ metadata
 group :integration do
   cookbook 'minitest-handler'
 end
-
-# Temporary, until Java 1.8 support is released
-cookbook 'java', :git => 'https://github.com/agileorbit-cookbooks/java.git'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,12 +19,13 @@
 #
 
 # You can choose 'latest' as version, but keep in mind that whenever Saucelabs does a new release, your proxy will restart!
-default['sauceconnect']['server']['version'] = '3.1-r32'
+default['sauceconnect']['server']['version'] = '4.3.10'
 default['sauceconnect']['server']['download_url'] = 'http://saucelabs.com/downloads'
-default['sauceconnect']['server']['zipfile'] = "Sauce-Connect-#{node['sauceconnect']['server']['version']}.zip"
+default['sauceconnect']['server']['tarball'] = "sc-#{node['sauceconnect']['server']['version']}-linux.tar.gz"
 default['sauceconnect']['server']['install_dir'] = '/opt/sauceconnect'
 default['sauceconnect']['server']['user'] = 'sauceprx'
-default['sauceconnect']['server']['log_file'] = "#{node['sauceconnect']['server']['install_dir']}/sauce_connect.log"
+default['sauceconnect']['server']['log_file'] = "#{node['sauceconnect']['server']['install_dir']}/sauceconnect.log"
+default['sauceconnect']['server']['pid_file'] = "/var/run/sauceconnect.pid"
 
 # Typically overridden in the role
 default['sauceconnect']['server']['api_user'] = ''

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,5 +9,3 @@ version          '0.1.10'
 %w(fedora redhat centos oracle amazon scientific).each do |p|
   supports p
 end
-
-depends 'java'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,6 +23,7 @@ user node['sauceconnect']['server']['user'] do
   comment 'SauceLabs Proxy User'
   system true
   action :create
+  shell '/bin/false'
 end
 
 directory node['sauceconnect']['server']['install_dir'] do
@@ -31,20 +32,15 @@ directory node['sauceconnect']['server']['install_dir'] do
   action :create
 end
 
-# Can't assume we have unzip
-package 'unzip' do
-  action :install
-end
-
 execute 'unzip-saucelabs-proxy' do
   cwd node['sauceconnect']['server']['install_dir']
-  command "unzip -o #{Chef::Config[:file_cache_path]}/#{node['sauceconnect']['server']['zipfile']}"
+  command "tar -xzv -C #{node['sauceconnect']['server']['install_dir']} -f #{Chef::Config[:file_cache_path]}/#{node['sauceconnect']['server']['tarball']} --strip-components 1"
   action :nothing
   notifies :restart, 'service[sauceconnect]'
 end
 
-remote_file "#{Chef::Config[:file_cache_path]}/#{node['sauceconnect']['server']['zipfile']}" do
-  source "#{node['sauceconnect']['server']['download_url']}/#{node['sauceconnect']['server']['zipfile']}"
+remote_file "#{Chef::Config[:file_cache_path]}/#{node['sauceconnect']['server']['tarball']}" do
+  source "#{node['sauceconnect']['server']['download_url']}/#{node['sauceconnect']['server']['tarball']}"
   action :create
   notifies :run, 'execute[unzip-saucelabs-proxy]', :immediately
 end

--- a/templates/default/sauceconnect.init.erb
+++ b/templates/default/sauceconnect.init.erb
@@ -31,22 +31,20 @@
 # Source config file if it exists
 [ -r /etc/sysconfig/sauceconnect ] && . /etc/sysconfig/sauceconnect
 
-jarfile=${JARFILE-<%= node['sauceconnect']['server']['install_dir'] %>/Sauce-Connect.jar}
-logfile=${LOGFILE-<%= node['sauceconnect']['server']['install_dir'] %>/sauce_connect.log}
-sauceuser=${SAUCEUSER-root}
-apiuser=${APIUSER-bogus}
-apikey=${APIKEY-bogus}
-
-[ -r $JARFILE ] || exit 0
+logfile=${LOGFILE}
+sauceuser=${SAUCEUSER}
+apiuser=${APIUSER}
+apikey=${APIKEY}
+pidfile=${PIDFILE}
 
 start() {
   ulimit -n 10240
-  daemon --user $SAUCEUSER "java -jar $jarfile -l $logfile $apiuser $apikey &"
+  daemon --user $SAUCEUSER "/opt/sauceconnect/bin/sc -l $logfile -u $apiuser -k $apikey > /dev/null 2>&1 &"
 }
 
 stop() {
   # This is rather dirty. But it'll do for now.
-  pkill -U $SAUCEUSER java
+  pkill -U $SAUCEUSER sc
 }
 
 case $1 in

--- a/templates/default/sauceconnect.sysconfig.erb
+++ b/templates/default/sauceconnect.sysconfig.erb
@@ -4,3 +4,4 @@ SAUCEUSER=<%= node['sauceconnect']['server']['user'] %>
 APIUSER=<%= node['sauceconnect']['server']['api_user'] %>
 APIKEY=<%= node['sauceconnect']['server']['api_key'] %>
 LOGFILE=<%= node['sauceconnect']['server']['log_file'] %>
+PIDFILE=<%= node['sauceconnect']['server']['pid_file'] %>


### PR DESCRIPTION
with the caveats of;
- only tested on 64 bit centos 6.6 (will need a different init script likely for ubuntu), because it is now c-based there is also a 32 bit version
- needs windows support
- needs osx support
- doesn't support all the new options/flags
- didn't run / fix any of the tests
